### PR TITLE
Add a cache version endpoint for external caching

### DIFF
--- a/core/scripts/server.ts
+++ b/core/scripts/server.ts
@@ -2,6 +2,7 @@ import { serverHooksExecutors } from '@vue-storefront/core/server/hooks'
 let config = require('config')
 const path = require('path')
 const glob = require('glob')
+const fs = require('fs')
 const rootPath = require('app-root-path').path
 const resolve = file => path.resolve(rootPath, file)
 const serverExtensions = glob.sync('src/modules/*/server.{ts,js}')
@@ -145,6 +146,12 @@ app.use('/service-worker.js', serve('dist/service-worker.js', false, {
 
 app.post('/invalidate', invalidateCache)
 app.get('/invalidate', invalidateCache)
+
+function cacheVersion (req, res) {
+  res.send(fs.readFileSync(resolve('core/build/cache-version.json')))
+}
+
+app.get('/cache-version.json', cacheVersion)
 
 app.get('*', (req, res, next) => {
   if (NOT_ALLOWED_SSR_EXTENSIONS_REGEX.test(req.url)) {


### PR DESCRIPTION
### Related Issues

https://github.com/ClickAndMortar/docker/issues/5

### Short Description and Why It's Useful

Useful to fetch current cache version, to leverage Redis caching from an external proxy for instance.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

